### PR TITLE
Simplified version removes pipenv dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,20 @@ $ bash <(curl -fsSL https://raw.githubusercontent.com/admobilize/trail-installer
 # On bash
 $ bash <(curl -fsSL https://raw.githubusercontent.com/admobilize/trail-installer/master/install.sh) && source ~/.bashrc
 ```
+
+## Troubleshooting
+
+**If you experience Python build issues in Linux Debian/Ubuntu**
+
+Make sure the following dependencies are installed: 
+
+```
+apt-get update && apt-get install --yes \
+  build-essential \
+  libffi-dev \
+  libssl-dev \
+  libreadline-dev \
+  libbz2-dev \
+  libsqlite3-dev \
+  zlib1g-dev
+```

--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,7 @@ create_trail_pyenv () {
         echo "pyenv version ${TRAIL_PYENV} exists, re-create ?"
         read YES_NO
         if [ "$YES_NO" = "y" ]; then
-            pyenv virtualenv-delete $TRAIL_PYENV
+            pyenv virtualenv-delete -f $TRAIL_PYENV
             pyenv virtualenv $REQUIRED_PYTHON_VERSION trail-cli
         fi
     else

--- a/install.sh
+++ b/install.sh
@@ -16,13 +16,14 @@ fi
 REQUIRED_PYTHON_VERSION="3.7.4"
 REQUIRED_PYTHON_VERSION_MIN="3.7"
 TRAIL_CONFIG_DIR=$HOME/.config/trailcli
-PIPCONF_FILE=$HOME/.config/pip/pip.conf
 BUILD_DIR=$TRAIL_CONFIG_DIR/build
 DEBUG_FILE=/tmp/trail-installer.log
 # Reuse the default PYENV_ROOT if exists
 PYENV_ROOT=${PYENV_ROOT:-$HOME/.pyenv}
 TRAIL_PYENV=${TRAIL_PYENV:-trail-cli}
-PYENV_TRAIL_BIN_DIR=$PYENV_ROOT/versions/$TRAIL_PYENV/bin
+PYENV_TRAIL_DIR=$PYENV_ROOT/versions/$TRAIL_PYENV
+PYENV_TRAIL_BIN_DIR=$PYENV_TRAIL_DIR/bin
+PIPCONF_FILE=$PYENV_TRAIL_DIR/pip.conf
 
 
 # Check if admobilize pypi username was passed
@@ -61,8 +62,6 @@ PYENV_BASH_LINE_1="# trail-pyenv-start"
 PYENV_BASH_LINE_2="alias trail=\"$PYENV_TRAIL_BIN_DIR/trail\""
 PYENV_BASH_LINE_3="export PATH=\"$PYENV_ROOT/bin:\$PATH\""
 PYENV_BASH_LINE_4="# trail-pyenv-end"
-PIPCONF_BASH_LINE_1="[global]"
-PIPCONF_BASH_LINE_2="index-url = https://$PYPI_USERNAME:$PYPI_PASSWORD@pypi.admobilize.com"
 
 install_pyenv () {
     if [ -d "$PYENV_ROOT/bin" ]; then
@@ -101,13 +100,6 @@ install_python () {
     pyenv rehash
 }
 
-check_pip () {
-    if ! command -v pip 1>/dev/null; then
-        echo "Pip not available. Please, install pip and run this script again."
-        exit 1
-    fi
-}
-
 create_trail_pyenv () {
     if pyenv versions | grep -q "$TRAIL_PYENV"; then
         echo "pyenv version ${TRAIL_PYENV} exists, re-create ?"
@@ -128,17 +120,13 @@ add_admob_repo_to_pipconf () {
         mkdir -p $PIPCONF_DIR
     fi
 
-    if [ ! -f "$PIPCONF_FILE" ]; then
-        touch $PIPCONF_FILE
-    fi
-
-    array=("$PIPCONF_BASH_LINE_1" "$PIPCONF_BASH_LINE_2")
-    for LINE in "${array[@]}"; do
-        if ! grep -Fxq "$LINE" $PIPCONF_FILE; then
-            echo "Adding $LINE to $PIPCONF_FILE"
-            echo -e "$LINE" >> $PIPCONF_FILE
-        fi
-    done
+	cat > $PIPCONF_FILE <<- EOF
+	[global]
+	timeout = 60
+	index-url = https://$PYPI_USERNAME:$PYPI_PASSWORD@pypi.admobilize.com
+EOF
+    unset PYPI_USERNAME
+    unset PYPI_PASSWORD
 }
 
 install_trail () {

--- a/install.sh
+++ b/install.sh
@@ -2,16 +2,31 @@
 
 set -e
 
-if [ $# -gt 2 ]
-then
+if [ $# -gt 2 ]; then
     echo "Too many arguments passed."
     echo "Usage: install.sh [admobilize_pypi_username [admobilize_pypi_password]]"
     exit 1
 fi
 
+if ! command -v git 1>/dev/null; then
+    echo "Install git before trying to run this script."
+    exit 1
+fi
+
+REQUIRED_PYTHON_VERSION="3.7.4"
+REQUIRED_PYTHON_VERSION_MIN="3.7"
+TRAIL_CONFIG_DIR=$HOME/.config/trailcli
+PIPCONF_FILE=$HOME/.config/pip/pip.conf
+BUILD_DIR=$TRAIL_CONFIG_DIR/build
+DEBUG_FILE=/tmp/trail-installer.log
+# Reuse the default PYENV_ROOT if exists
+PYENV_ROOT=${PYENV_ROOT:-$HOME/.pyenv}
+TRAIL_PYENV=${TRAIL_PYENV:-trail-cli}
+PYENV_TRAIL_BIN_DIR=$PYENV_ROOT/versions/$TRAIL_PYENV/bin
+
+
 # Check if admobilize pypi username was passed
-if [ "$1" ]
-then
+if [ "$1" ]; then
     PYPI_USERNAME=$1
     # If there's an username, check if the password was passed
     if [ "$2" ]
@@ -20,76 +35,64 @@ then
     fi
 fi
 
-REQUIRED_PYTHON_VERSION="3.7.4"
-REQUIRED_PYTHON_VERSION_MIN="3.7"
-TRAIL_CONFIG_DIR=$HOME/.config/trailcli
-BUILD_DIR=$TRAIL_CONFIG_DIR/build
-DEBUG_FILE=/tmp/trail-installer.log
-PYENV_ROOT=$HOME/.pyenv
-PYENV_BIN_DIR=$PYENV_ROOT/versions/$REQUIRED_PYTHON_VERSION/bin
 
-if [ -n "`$SHELL -c 'echo $ZSH_VERSION'`" ]
-then
-	PROFILE_FILE=$HOME/.zshrc
-elif [ -n "`$SHELL -c 'echo $BASH_VERSION'`" ]
-then
-	PROFILE_FILE=$HOME/.bashrc
+if [ -n "`$SHELL -c 'echo $ZSH_VERSION'`" ]; then
+    PROFILE_FILE=$HOME/.zshrc
+elif [ -n "`$SHELL -c 'echo $BASH_VERSION'`" ]; then
+    PROFILE_FILE=$HOME/.bashrc
 else
     echo "Unsupported shell: $SHELL"
     echo "Run again on bash or zsh."
     exit 1
 fi
 
-if [ -z "$PYPI_USERNAME" ]
-then
+if [ -z "$PYPI_USERNAME" ]; then
     echo -n "Pypi Username: "
     read PYPI_USERNAME
 fi
 
-if [ -z "$PYPI_PASSWORD" ]
-then
+if [ -z "$PYPI_PASSWORD" ]; then
     echo -n "Pypi Password: "
     read -s PYPI_PASSWORD
 fi
 echo ""
 
 PYENV_BASH_LINE_1="# trail-pyenv-start"
-PYENV_BASH_LINE_2="export PATH=$HOME/.pyenv/bin:\$PATH"
-PYENV_BASH_LINE_3="export PYENV_VERSION=$REQUIRED_PYTHON_VERSION"
+PYENV_BASH_LINE_2="alias trail=\"$PYENV_TRAIL_BIN_DIR/trail\""
+PYENV_BASH_LINE_3="PATH=\"$PYENV_ROOT/bin:$PATH\""
 PYENV_BASH_LINE_4="# trail-pyenv-end"
-
-PIPENV_BASH_LINE_1="# trail-pipenv-start"
-PIPENV_BASH_LINE_2="export PIPENV_PIPFILE=$BUILD_DIR/Pipfile"
-PIPENV_BASH_LINE_3="alias trail=\"$PYENV_BIN_DIR/pipenv run trail\""
-PIPENV_BASH_LINE_4='# trail-pipenv-end'
+PIPCONF_BASH_LINE_1="[global]"
+PIPCONF_BASH_LINE_2="index-url = https://$PYPI_USERNAME:$PYPI_PASSWORD@pypi.admobilize.com"
 
 install_pyenv () {
-    if [ -d "$HOME/.pyenv/bin" ]
-    then
+    if [ -d "$PYENV_ROOT/bin" ]; then
         export PATH=$PYENV_ROOT/bin:$PATH
         eval "$(pyenv init -)"
         eval "$(pyenv virtualenv-init -)"
     fi
-	if ! command -v pyenv 1>/dev/null
-	then
-		echo "Installing pyenv..."
-		curl -L https://raw.githubusercontent.com/admobilize/trail-installer/master/pyenv-installer.sh | bash 1>$DEBUG_FILE 2>&1
+
+    if ! command -v pyenv 1>/dev/null; then
+        echo "Installing pyenv..."
+        curl -L https://raw.githubusercontent.com/admobilize/trail-installer/master/pyenv-installer.sh | bash 1>$DEBUG_FILE 2>&1
         echo "Done"
-	fi
-	array=("$PYENV_BASH_LINE_1" "$PYENV_BASH_LINE_2" "$PYENV_BASH_LINE_3" "$PYENV_BASH_LINE_4")
-	for LINE in "${array[@]}"; do
-		if ! grep -Fxq "$LINE" $PROFILE_FILE
-		then
-			echo "Adding $LINE to $PROFILE_FILE"
-			echo -e "$LINE" >> $PROFILE_FILE
-		fi
-		eval "$LINE"
-	done
+        export PATH=$PYENV_ROOT/bin:$PATH
+        eval "$($PYENV_ROOT/bin/pyenv init -)"
+        eval "$($PYENV_ROOT/bin/pyenv virtualenv-init -)"
+    fi
+
+    array=("$PYENV_BASH_LINE_1" "$PYENV_BASH_LINE_2" "$PYENV_BASH_LINE_3" "$PYENV_BASH_LINE_4")
+    for LINE in "${array[@]}"; do
+        if ! grep -Fxq "$LINE" $PROFILE_FILE
+        then
+            echo "Adding $LINE to $PROFILE_FILE"
+            echo -e "$LINE" >> $PROFILE_FILE
+        fi
+        eval "$LINE"
+    done
 }
 
 install_python () {
-	if ! command -v pyenv 1>/dev/null
-	then
+    if ! command -v pyenv 1>/dev/null; then
         echo "Install pyenv before trying to install python."
         exit 1
     fi
@@ -99,57 +102,58 @@ install_python () {
 }
 
 check_pip () {
-	if ! command -v pip 1>/dev/null
-	then
-		echo "Pip not available. Please, install pip and run this script again."
-		exit 1
-	fi
-
+    if ! command -v pip 1>/dev/null; then
+        echo "Pip not available. Please, install pip and run this script again."
+        exit 1
+    fi
 }
 
-install_pipenv () {
-	echo "Installing pipenv.."
-	$PYTHON -m pip install --force-reinstall --isolated --no-cache-dir --disable-pip-version-check pipenv
+create_trail_pyenv () {
+    if pyenv versions | grep -q "$TRAIL_PYENV"; then
+        echo "pyenv version ${TRAIL_PYENV} exists, re-create ?"
+        read YES_NO
+        if [ "$YES_NO" = "y" ]; then
+            pyenv remove $TRAIL_PYENV
+            pyenv virtualenv $REQUIRED_PYTHON_VERSION trail-cli
+        fi
+    else
+        pyenv virtualenv $REQUIRED_PYTHON_VERSION trail-cli
+    fi
 }
 
-create_pipfile () {
-	OLD_DIR=$(pwd)
-	mkdir -p $BUILD_DIR && cd $BUILD_DIR
-	cat > Pipfile <<- EOF
-	[[source]]
-	name = "admobilize-pypi"
-	url = "https://$PYPI_USERNAME:$PYPI_PASSWORD@pypi.admobilize.com"
-	verify_ssl = true
-EOF
-    unset PYPI_USERNAME
-    unset PYPI_PASSWORD
-	cd $OLD_DIR
+add_admob_repo_to_pipconf () {
+
+    PIPCONF_DIR=$(dirname $PIPCONF_FILE)
+    if [ ! -d "$PIPCONF_DIR" ]; then
+        mkdir -p $PIPCONF_DIR
+    fi
+
+    if [ ! -f "$PIPCONF_FILE" ]; then
+        touch $PIPCONF_FILE
+    fi
+
+    array=("$PIPCONF_BASH_LINE_1" "$PIPCONF_BASH_LINE_2")
+    for LINE in "${array[@]}"; do
+        if ! grep -Fxq "$LINE" $PIPCONF_FILE; then
+            echo "Adding $LINE to $PIPCONF_FILE"
+            echo -e "$LINE" >> $PIPCONF_FILE
+        fi
+    done
 }
 
 install_trail () {
-	OLD_DIR=$(pwd)
-	mkdir -p $BUILD_DIR && cd $BUILD_DIR
-    $PYENV_BIN_DIR/pipenv install --python $PYENV_BIN_DIR/python trail-core
-	array=("$PIPENV_BASH_LINE_1" "$PIPENV_BASH_LINE_2" "$PIPENV_BASH_LINE_3" "$PIPENV_BASH_LINE_4")
-	for LINE in "${array[@]}"; do
-		if ! grep -Fxq "$LINE" $PROFILE_FILE
-		then
-			echo "Adding $LINE to $PROFILE_FILE"
-			echo -e "$LINE" >> $PROFILE_FILE
-		fi
-		eval "$LINE"
-	done
-	cd $OLD_DIR
+    pyenv activate $TRAIL_PYENV
+    $PYENV_TRAIL_BIN_DIR/pip install trail-core
+    echo "Done"
 }
 
 install_pyenv
 install_python
-PYTHON=$(pyenv which python$REQUIRED_PYTHON_VERSION_MIN)
-install_pipenv
-create_pipfile
+create_trail_pyenv
+add_admob_repo_to_pipconf
 install_trail
 
 echo ""
 echo "Trail installation complete!"
 echo "To start using it right away, run the following command:"
-echo "source $PROFILE_FILE"
+echo "source $PROFILE_FILE to load the trail alias"

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ echo ""
 
 PYENV_BASH_LINE_1="# trail-pyenv-start"
 PYENV_BASH_LINE_2="alias trail=\"$PYENV_TRAIL_BIN_DIR/trail\""
-PYENV_BASH_LINE_3="PATH=\"$PYENV_ROOT/bin:$PATH\""
+PYENV_BASH_LINE_3="export PATH=\"$PYENV_ROOT/bin:\$PATH\""
 PYENV_BASH_LINE_4="# trail-pyenv-end"
 PIPCONF_BASH_LINE_1="[global]"
 PIPCONF_BASH_LINE_2="index-url = https://$PYPI_USERNAME:$PYPI_PASSWORD@pypi.admobilize.com"
@@ -113,7 +113,7 @@ create_trail_pyenv () {
         echo "pyenv version ${TRAIL_PYENV} exists, re-create ?"
         read YES_NO
         if [ "$YES_NO" = "y" ]; then
-            pyenv remove $TRAIL_PYENV
+            pyenv virtualenv-delete $TRAIL_PYENV
             pyenv virtualenv $REQUIRED_PYTHON_VERSION trail-cli
         fi
     else
@@ -143,7 +143,8 @@ add_admob_repo_to_pipconf () {
 
 install_trail () {
     pyenv activate $TRAIL_PYENV
-    $PYENV_TRAIL_BIN_DIR/pip install trail-core
+    $PYENV_TRAIL_BIN_DIR/pip install --upgrade pip
+    $PYENV_TRAIL_BIN_DIR/pip install --force-reinstall --upgrade trail-core
     echo "Done"
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,6 +4,7 @@ TRAIL_CONFIG_DIR=$HOME/.config/trailcli
 REQUIRED_PYTHON_VERSION="3.7.4"
 PYENV_DIR=$HOME/.pyenv
 PYENV_BIN_DIR=$PYENV_DIR/versions/$REQUIRED_PYTHON_VERSION/bin
+TRAIL_PYENV=${TRAIL_PYENV:-trail-cli}
 
 if [ -n "`$SHELL -c 'echo $ZSH_VERSION'`" ]
 then
@@ -34,24 +35,15 @@ uninstall_pyenv () {
 }
 
 remove_virtualenv () {
-
-    if [ -f "$PYENV_BIN_DIR/pipenv" ]
+    if command -v pyenv 1>/dev/null
     then
-        VIRTUAL_ENV_DIR=$($PYENV_BIN_DIR/pipenv --venv)
-        if [ -d "$VIRTUAL_ENV_DIR" ]
-        then
-            rm -rf $VIRTUAL_ENV_DIR
-            echo "virtualenv dir deleted."
-        fi
+        pyenv virtualenv-delete -f $TRAIL_PYENV
+        echo "$TRAIL_PYENV virtualenv deleted."
     fi
 }
 
 remove_pyenv_source_lines () {
     sed -i.bak '/# trail-pyenv-start/,/# trail-pyenv-end/d' $PROFILE_FILE && rm $PROFILE_FILE.bak
-}
-
-remove_pipenv_source_lines () {
-    sed -i.bak '/# trail-pipenv-start/,/# trail-pipenv-end/d' $PROFILE_FILE && rm $PROFILE_FILE.bak
 }
 
 remove_trail_config () {
@@ -63,7 +55,6 @@ remove_trail_config () {
 }
 
 remove_virtualenv
-remove_pipenv_source_lines
 remove_trail_config
 remove_pyenv_source_lines
 uninstall_pyenv


### PR DESCRIPTION
This install script removes the pipenv dependency and creates a "namespaced" `trail-cli` pyenv version that contains the `trail`  command. 

There is one more check that could be added. The Python build done when pyenv installs a python version, attempts to build in the `LDFLAGS` prefix directory. Perhaps a check that this directory is writable by the current user would be nice.